### PR TITLE
fix: remove echo of username or password on basic auth

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,8 +33,6 @@ elif [ "$BASIC_AUTH_ENABLED" = "true" ]; then
     # Prepare the password file
     touch "/var/lib/dav/user.passwd"
     echo "$BASIC_USERS" | tr ' ' '\n' | while IFS=':' read -r USERNAME PASSWORD; do
-        # Output the username and password
-        echo "Username: $USERNAME, Password: $PASSWORD"
         HASH="`printf '%s' "$USERNAME:$BASIC_AUTH_REALM:$PASSWORD" | md5sum | awk '{print $1}'`"
         printf '%s\n' "$USERNAME:$BASIC_AUTH_REALM:$HASH" >> /var/lib/dav/user.passwd
     done


### PR DESCRIPTION
# Current Behaviour
N/A
# Expected Behaviour
- Don't display credentials on logs basic auth