### PR TITLE
Fix/oauth

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,6 @@ LDAP_BIND_PASSWORD=securepassword
 OAUTH_ENABLED=true
 OIDCProviderMetadataURL="http://keycloak/keycloak-auth/realms/master/.well-known/openid-configuration"
 OIDCRedirectURI="http://my-domain.local/redirect_uri"
-OIDCDefaultURL="http://my-domain.local"
 OIDCCryptoPassphrase="randomly_generated_secure_passphrase"
 OIDCClientID="webdav-client"
 OIDCClientSecret="ABC123def456GHI789jkl0mnopqrs"

--- a/.env
+++ b/.env
@@ -7,14 +7,19 @@ LDAP_BIND_DN=uid=searchuser,ou=users,dc=example,dc=com
 LDAP_BIND_PASSWORD=securepassword
 
 # OAUTH Configuration
-OAUTH_ENABLED=false
-OAUTH_CLIENT_ID=1234567890-abcdefghijklm.apps.googleusercontent.com
-OAUTH_CLIENT_SECRET=ABC123def456GHI789jkl0mnopqrs
-OAUTH_SCOPE="openid email profile"
-OAUTH_REDIRECT_URI=http://localhost
-OAUTH_METADATA_URL="https://accounts.google.com/.well-known/openid-configuration"
-OAUTH_CRYPTO_PASSPHRASE=mysecurepassphrase
-OAUTH_FORWARDED_HEADER=X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto
+# Keycloak OIDC configuration
+# more options: https://github.com/OpenIDC/mod_auth_openidc
+OAUTH_ENABLED=true
+OIDCProviderMetadataURL="http://keycloak/keycloak-auth/realms/master/.well-known/openid-configuration"
+OIDCRedirectURI="http://my-domain.local/redirect_uri"
+OIDCDefaultURL="http://my-domain.local"
+OIDCCryptoPassphrase="randomly_generated_secure_passphrase"
+OIDCClientID="webdav-client"
+OIDCClientSecret="ABC123def456GHI789jkl0mnopqrs"
+OIDCProviderTokenEndpointAuth="client_secret_basic"
+OIDCRemoteUserClaim="preferred_username"
+OIDCScope="openid email profile"
+OIDCXForwardedHeaders="X-Forwarded-Host"
 
 # Basic Digest Authentication with users space separated
 BASIC_AUTH_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -38,16 +38,19 @@ BASIC_USERS=alice:alice123 bob:bob123
 ```
 
 ### 🔐 OAuth Authentication
-OAuth authentication (example with Google OAuth) configuration:
+OAuth authentication (example with Keycloak) configuration:
 ```
 OAUTH_ENABLED=true
-OAUTH_CLIENT_ID=1234567890-abcdefghijklm.apps.googleusercontent.com
-OAUTH_CLIENT_SECRET=ABC123def456GHI789jkl0mnopqrs
-OAUTH_SCOPE="openid email profile"
-OAUTH_REDIRECT_URI=http://localhost
-OAUTH_METADATA_URL="https://accounts.google.com/.well-known/openid-configuration"
-OAUTH_CRYPTO_PASSPHRASE=mysecurepassphrase
-OAUTH_FORWARDED_HEADER=X-Forwarded-Host,X-Forwarded-Port,X-Forwarded-Proto
+OIDCProviderMetadataURL="http://keycloak/keycloak-auth/realms/master/.well-known/openid-configuration"
+OIDCRedirectURI="http://my-domain.local/redirect_uri"
+OIDCDefaultURL="http://my-domain.local"
+OIDCCryptoPassphrase="randomly_generated_secure_passphrase"
+OIDCClientID="webdav-client"
+OIDCClientSecret="ABC123def456GHI789jkl0mnopqrs"
+OIDCProviderTokenEndpointAuth="client_secret_basic"
+OIDCRemoteUserClaim="preferred_username"
+OIDCScope="openid email profile"
+OIDCXForwardedHeaders="X-Forwarded-Host"
 ```
 
 ### 🔐 LDAP Authentication

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ BASIC_USERS=alice:alice123 bob:bob123
 ```
 
 ### 🔐 OAuth Authentication
-OAuth authentication (example with Keycloak) configuration:
+OAuth authentication ([example with Keycloak](https://github.com/vaggeliskls/devops-docker-projects/tree/main/charts/keycloak-webdav)) configuration:
 ```
 OAUTH_ENABLED=true
 OIDCProviderMetadataURL="http://keycloak/keycloak-auth/realms/master/.well-known/openid-configuration"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ OAuth authentication ([example with Keycloak](https://github.com/vaggeliskls/dev
 OAUTH_ENABLED=true
 OIDCProviderMetadataURL="http://keycloak/keycloak-auth/realms/master/.well-known/openid-configuration"
 OIDCRedirectURI="http://my-domain.local/redirect_uri"
-OIDCDefaultURL="http://my-domain.local"
 OIDCCryptoPassphrase="randomly_generated_secure_passphrase"
 OIDCClientID="webdav-client"
 OIDCClientSecret="ABC123def456GHI789jkl0mnopqrs"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,8 +13,22 @@ comment_block() {
     sed -i "/# ${block_name}_START/,/# ${block_name}_END/ s/^[^#]/# &/" "/usr/local/apache2/conf/webdav.conf"
 }
 
+# Function to dynamically add OIDC environment variables
+add_oidc_config() {
+    # Find all environment variables with OIDC prefix and add them to the config
+    for var in $(env | grep "^OIDC" | cut -d'=' -f1); do
+        # Get the actual value of the environment variable
+        var_value=$(eval echo \$$var)
+        # Insert the directive after the LoadModule line with actual value
+        sed -i "/LoadModule auth_openidc_module/a\\
+$var \"$var_value\"" "/usr/local/apache2/conf/webdav.conf"
+    done
+}
+
 envsubst < /usr/local/apache2/conf/webdav.conf.template > /usr/local/apache2/conf/webdav.conf
 envsubst < /usr/local/apache2/conf/virtualhost.conf.template > /usr/local/apache2/conf/virtualhost.conf
+
+add_oidc_config
 
 comment_block "OAUTH_BLOCK"
 comment_block "LDAP_BLOCK"

--- a/webdav.conf
+++ b/webdav.conf
@@ -4,13 +4,6 @@ Alias / "/var/lib/dav/data/"
 
 ## OAUTH_BLOCK_START
 LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
-OIDCRedirectURI "${OAUTH_REDIRECT_URI}"
-OIDCProviderMetadataURL "${OAUTH_METADATA_URL}"
-OIDCClientID "${OAUTH_CLIENT_ID}"
-OIDCClientSecret "${OAUTH_CLIENT_SECRET}"
-OIDCScope "${OAUTH_SCOPE}"
-OIDCCryptoPassphrase "${OAUTH_CRYPTO_PASSPHRASE}"
-OIDCXForwardedHeaders ${OAUTH_FORWARDED_HEADER}
 ## OAUTH_BLOCK_END
 
 <Directory "/var/lib/dav/data/">


### PR DESCRIPTION
This pull request introduces a migration from Google OAuth to Keycloak OIDC for authentication, along with updates to configuration files, documentation, and the Docker entrypoint script to support the new setup.

### Authentication Migration to Keycloak OIDC:

* [`.env`](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dL10-R22): Replaced Google OAuth configuration with Keycloak OIDC configuration, including new environment variables such as `OIDCProviderMetadataURL`, `OIDCClientID`, and `OIDCScope`. This enables integration with Keycloak for authentication.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R53): Updated the OAuth configuration example to reflect the Keycloak setup, replacing Google OAuth details with Keycloak-specific parameters. Added a reference to a Keycloak example project.

### Docker Entrypoint Enhancements:

* [`docker-entrypoint.sh`](diffhunk://#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aR16-R32): Added a new `add_oidc_config` function to dynamically inject OIDC-related environment variables into the Apache configuration file during container startup. This ensures the configuration is automatically updated based on the environment.

### Apache Configuration Updates:

* [`webdav.conf`](diffhunk://#diff-db1262ec7dbe4178d15dae2478900de739c04d41cad68e9aafd8fb238e66fedfL7-L13): Removed placeholder variables for Google OAuth and replaced them with directives for Keycloak OIDC. These directives will now be populated dynamically by the `add_oidc_config` function in the entrypoint script.