### PR TITLE
feat: readonly files

### DIFF
--- a/webdav.conf
+++ b/webdav.conf
@@ -60,6 +60,10 @@ LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
   ## PUBLIC_BLOCK_START
   Require all granted
   ## PUBLIC_BLOCK_END
+
+  <LimitExcept GET OPTIONS PROPFIND>
+    Require all denied
+  </LimitExcept>
 </Directory>
 
 # These disable redirects on non-GET requests for directories that


### PR DESCRIPTION
This pull request introduces a security enhancement to the `webdav.conf` file by restricting access methods to only `GET`, `OPTIONS`, and `PROPFIND` within the specified directory configuration.

### Security enhancement:

* [`webdav.conf`](diffhunk://#diff-db1262ec7dbe4178d15dae2478900de739c04d41cad68e9aafd8fb238e66fedfR63-R66): Added a `<LimitExcept>` directive to deny all methods except `GET`, `OPTIONS`, and `PROPFIND`, ensuring tighter control over allowed HTTP methods.