### PR TITLE
fix: remove the delete of templates

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,6 +60,5 @@ fi
 
 echo "Include conf/webdav.conf" >> /usr/local/apache2/conf/httpd.conf
 echo "Include conf/virtualhost.conf" >> /usr/local/apache2/conf/httpd.conf
-rm -rf /usr/local/apache2/conf/*.template
 
 exec "$@"


### PR DESCRIPTION
This pull request makes a minor change to the `docker-entrypoint.sh` script by removing a line that deleted all `.template` files from the Apache configuration directory. This change helps preserve template files that may be needed later.