### PR TITLE
feat: exlude user

### DIFF
--- a/.env
+++ b/.env
@@ -11,14 +11,16 @@ SERVER_NAME=localhost
 #   /path:users:mode
 #
 #   path  — folder path under the data directory (must start with /)
-#   users — "public"     = no authentication required
-#           "*"          = any authenticated user
-#           "alice bob"  = specific users (space-separated)
+#   users — "public"      = no authentication required
+#           "*"           = any authenticated user
+#           "alice bob"   = specific users (space-separated)
+#           "* !charlie"  = any authenticated user except charlie
 #   mode  — "ro" = read-only  (uses RO_METHODS)
 #            "rw" = read-write (uses RW_METHODS)
 #
-# Example:
+# Examples:
 #   FOLDER_PERMISSIONS="/public:public:ro,/shared:*:ro,/private:alice bob:rw,/admin:admin:rw"
+#   FOLDER_PERMISSIONS="/shared:* !charlie:ro,/private:alice bob:rw"
 #
 # Leave empty to use legacy single-root mode (controlled by *_ENABLED flags below).
 FOLDER_PERMISSIONS="/public:public:ro,/private:*:ro"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight, Docker-based WebDAV server built on Apache httpd with flexible pe
 
 - 🗂️ **Per-folder access control** — different folders can have different auth rules and user restrictions
 - 🌍 **Public folders** — mix unauthenticated and authenticated folders on the same server
-- 👤 **Per-user permissions** — restrict specific folders to specific users
+- 👤 **Per-user permissions** — include or exclude specific users per folder
 - 🔐 **Multiple auth methods** — Basic, LDAP, OAuth/OIDC (or LDAP + Basic combined)
 - ⚙️ **Configurable methods** — control read-only vs read-write access per folder
 - 🌐 **CORS support** — configurable for web clients
@@ -36,9 +36,22 @@ The main configuration point. Controls which folders exist, who can access them,
 
 ```env
 # Format: "/path:users:mode" comma-separated
-# users: public | * | alice bob (space-separated)
+# users: public        — no authentication required
+#        *             — any authenticated user
+#        alice bob     — specific users (space-separated)
+#        * !charlie    — any authenticated user except charlie
 # mode:  ro (uses RO_METHODS) | rw (uses RW_METHODS)
 FOLDER_PERMISSIONS="/public:public:ro,/shared:*:ro,/private:alice bob:rw,/admin:admin:rw"
+```
+
+Prefix a username with `!` to exclude that user from an otherwise open folder:
+
+```env
+# All authenticated users can read /shared except charlie
+FOLDER_PERMISSIONS="/shared:* !charlie:ro"
+
+# Exclude multiple users
+FOLDER_PERMISSIONS="/shared:* !charlie !dave:rw"
 ```
 
 Folders are auto-created at startup (`AUTO_CREATE_FOLDERS=true`).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -108,7 +108,34 @@ services:
 
 ---
 
-## 5. 🏢 LDAP authentication
+## 5. 🚫 Exclude specific users from a folder
+
+Allow all authenticated users to access a folder except one or more explicitly blocked users.
+
+```yaml
+# docker-compose.yml
+services:
+  webdav:
+    image: ghcr.io/vaggeliskls/webdav-server:latest
+    ports:
+      - "80:8080"
+    volumes:
+      - ./data:/var/lib/dav/data
+    environment:
+      SERVER_NAME: localhost
+      FOLDER_PERMISSIONS: "/shared:* !charlie:ro,/private:alice bob:rw"
+      AUTO_CREATE_FOLDERS: "true"
+      BASIC_AUTH_ENABLED: "true"
+      BASIC_USERS: "alice:alice123 bob:bob123 charlie:charlie123"
+```
+
+- `GET http://localhost/shared/` with `alice` or `bob` → allowed
+- `GET http://localhost/shared/` with `charlie` → `403 Forbidden`
+- Multiple exclusions: `"* !charlie !dave"`
+
+---
+
+## 6. 🏢 LDAP authentication
 
 Authenticate users against an LDAP/Active Directory server. All authenticated users can access `/files`.
 
@@ -135,7 +162,7 @@ services:
 
 ---
 
-## 6. 🔀 LDAP with Basic Auth fallback
+## 7. 🔀 LDAP with Basic Auth fallback
 
 Apache tries LDAP first. If LDAP is unreachable or the user is not found, it falls back to the local password file.
 
@@ -164,7 +191,7 @@ services:
 
 ---
 
-## 7. 🔁 Behind Traefik reverse proxy
+## 8. 🔁 Behind Traefik reverse proxy
 
 Expose the server via Traefik with rate limiting. The `webdav` container is not directly port-exposed.
 
@@ -209,7 +236,7 @@ networks:
 
 ---
 
-## 8. 🧩 With CORS and health check
+## 9. 🧩 With CORS and health check
 
 Enable CORS for web clients and expose a health check endpoint for uptime monitoring.
 


### PR DESCRIPTION
This pull request introduces support for per-folder user exclusions in access control, allowing administrators to specify folders that are accessible to all authenticated users except certain explicitly excluded users. This is achieved by extending the `FOLDER_PERMISSIONS` syntax and updating both the documentation and the entrypoint logic to generate the correct Apache authorization directives. Comprehensive tests and documentation updates are included to demonstrate and verify the new feature.

**Access control and authorization improvements:**

* Added support for user exclusions in `FOLDER_PERMISSIONS` using the `!username` syntax (e.g., `* !charlie`), allowing any authenticated user except specified users to access a folder. This is implemented in the `docker-entrypoint.sh` by parsing exclusions and generating appropriate `<RequireAll>` and `<RequireNone>` blocks in Apache config.
* Ensured that excluded users receive a `403 Forbidden` response (not `401 Unauthorized`), providing clear feedback when access is denied due to exclusion.

**Documentation and examples:**

* Updated `README.md`, `.env`, and `docs/examples.md` to document the new exclusion syntax, provide usage examples, and clarify the permission model. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R56) [[3]](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR17-R23) [[4]](diffhunk://#diff-42c9e8de9b02b38190aa003b14db6be144d9d6f34b266cf401330e9e62a3bba9L111-R138) [[5]](diffhunk://#diff-364ece66f0a11a275c392299f96afd2f2856e3a3bf4798d76dd1d2f6f6b07587R120-R133)
* Added a new example scenario in `docs/examples.md` demonstrating user exclusion in a Docker Compose setup.

**Testing:**

* Expanded scenario 1 in `docs/tests.md` and `tests/scenario-1-basic-auth.sh` to include dedicated tests for user exclusion, verifying that excluded users are denied access with `403` while others are allowed. [[1]](diffhunk://#diff-364ece66f0a11a275c392299f96afd2f2856e3a3bf4798d76dd1d2f6f6b07587L19-R19) [[2]](diffhunk://#diff-364ece66f0a11a275c392299f96afd2f2856e3a3bf4798d76dd1d2f6f6b07587R32-R99) [[3]](diffhunk://#diff-dc600e48e97b241cbf48b58a52a5981b44a383a7c71acec7282e98106f54a457R71-R125)

**Other documentation updates:**

* Updated scenario numbering in `docs/examples.md` to reflect the new exclusion example. [[1]](diffhunk://#diff-42c9e8de9b02b38190aa003b14db6be144d9d6f34b266cf401330e9e62a3bba9L138-R165) [[2]](diffhunk://#diff-42c9e8de9b02b38190aa003b14db6be144d9d6f34b266cf401330e9e62a3bba9L167-R194) [[3]](diffhunk://#diff-42c9e8de9b02b38190aa003b14db6be144d9d6f34b266cf401330e9e62a3bba9L212-R239)