### PR TITLE
chore: pin httpd base image and add community links

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4
+FROM httpd:2.4.67
 
 # Metadata labels
 LABEL maintainer="vaggeliskls <https://github.com/vaggeliskls>"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A lightweight, Docker-based WebDAV server built on Apache httpd with flexible per-folder access control and multiple authentication options.
 
+> ⭐ **Find this useful?** Star the repo — it helps others discover the project.
+>
+> ☁️ **Looking for a managed cloud edition?** Check out [vaggeliskls/cloud-webdav-server](https://github.com/vaggeliskls/cloud-webdav-server).
+
 > **Pre-built image:** `ghcr.io/vaggeliskls/webdav-server:latest`
 
 > **Documentation:** https://vaggeliskls.github.io/webdav-server/


### PR DESCRIPTION
## Summary
- Pin Dockerfile base image to `httpd:2.4.67` for reproducible builds (was floating `httpd:2.4`).
- Add `.github/dependabot.yml` with weekly checks for Docker base image and GitHub Actions, so the pin doesn't go stale.
- Add a star CTA and a link to the [cloud-webdav-server](https://github.com/vaggeliskls/cloud-webdav-server) project at the top of the README.

