### PR TITLE
Security hardening: rate-limiting, Apache DoS mitigations, container/K8s hardening

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,20 @@ RO_METHODS="GET HEAD OPTIONS PROPFIND"
 RW_METHODS="GET HEAD OPTIONS PROPFIND PUT DELETE MKCOL COPY MOVE LOCK UNLOCK PROPPATCH"
 
 # ---------------------------------------------------------------------------
+# Request hardening (DoS / resource-exhaustion mitigations)
+# ---------------------------------------------------------------------------
+# Max upload (PUT) body size in bytes. 0 = unlimited (default).
+# Set e.g. 1073741824 (1 GiB) to prevent disk-fill via huge uploads.
+LIMIT_REQUEST_BODY=0
+# Max size of WebDAV XML control bodies (PROPFIND/PROPPATCH/LOCK), in bytes.
+# Does NOT affect file uploads. Default 1 MiB.
+LIMIT_XML_REQUEST_BODY=1048576
+# Allow recursive "Depth: infinity" PROPFIND (full-tree walk). Off = blocked
+# (recommended, avoids an amplification vector). Set On only if a client needs
+# recursive directory listing in a single request.
+DAV_DEPTH_INFINITY=Off
+
+# ---------------------------------------------------------------------------
 # LDAP Authentication
 # ---------------------------------------------------------------------------
 LDAP_ENABLED=false

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -25,3 +25,5 @@ jobs:
         run: ./tests/scenario-4-public-only.sh --no-build
       - name: "LDAP authentication"
         run: ./tests/scenario-5-ldap.sh --no-build
+      - name: "Write operations"
+        run: ./tests/scenario-6-write-ops.sh --no-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p "/var/www/html" && \
 RUN for i in \
     authn_core authn_file authz_core authz_user \
     ldap authnz_ldap ssl auth_basic auth_digest authn_dbm \
-    alias headers mime setenvif \
+    alias headers mime setenvif reqtimeout \
     dav dav_fs; \
     do \
     sed -i -e "/^#LoadModule ${i}_module.*/s/^#//" /usr/local/apache2/conf/httpd.conf; \
@@ -44,6 +44,11 @@ RUN sed -i 's/Listen 80/Listen 8080/' /usr/local/apache2/conf/httpd.conf && \
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Make the entrypoint script executable
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Allow running as an arbitrary UID with GID 0 (e.g. OpenShift). Done last so
+# it also covers the copied templates and the httpd.conf edited above.
+RUN chgrp -R 0 "/var/www/html" "/var/lib/dav" "/usr/local/apache2" && \
+    chmod -R g=u "/var/www/html" "/var/lib/dav" "/usr/local/apache2"
 
 # Expose the new higher ports
 EXPOSE 8080/tcp 8443/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,19 @@ services:
       - webdav-network
     env_file:
       - .env
+    # --- Runtime hardening -------------------------------------------------
+    # Container already runs as non-root (USER webuser) and binds :8080, so
+    # no capabilities are needed. read_only is NOT set: the entrypoint writes
+    # generated Apache config into /usr/local/apache2/conf at startup.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.webdav.service=webdav"
@@ -19,6 +32,19 @@ services:
       ## Use PathPrefix rule to catch all requests
       - "traefik.http.routers.webdav.rule=PathPrefix(`/`)"
       - "traefik.http.routers.webdav.entrypoints=web,websecure"
+      # Rate limiting + connection cap (per client IP) ========================
+      # average/burst/period throttle request rate; inflightreq caps
+      # simultaneous in-flight requests. Tune to your real traffic.
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.average=20"
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.burst=40"
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.period=1s"
+      # Limit is keyed on the direct client IP (Traefik's default). Clients
+      # connect to Traefik directly here, so do NOT trust X-Forwarded-For —
+      # a spoofed XFF would let an attacker rotate keys and bypass the limit.
+      # Only if a CDN/proxy sits IN FRONT of Traefik, add (depth = trusted hops):
+      #   traefik.http.middlewares.webdav-ratelimit.ratelimit.sourcecriterion.ipstrategy.depth=1
+      - "traefik.http.middlewares.webdav-inflight.inflightreq.amount=50"
+      - "traefik.http.routers.webdav.middlewares=webdav-ratelimit,webdav-inflight"
 
   webdav-proxy:
     image: traefik:v3
@@ -32,7 +58,10 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Read-only: Traefik only needs to read the Docker API, never write it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    security_opt:
+      - no-new-privileges:true
     networks:
       - webdav-network
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,14 @@ RW_METHODS="${RW_METHODS:-GET HEAD OPTIONS PROPFIND PUT DELETE MKCOL COPY MOVE L
 export DAV_LOCK_DB="${DAV_LOCK_DB:-/tmp/DavLock}"
 export DIRECTORY_SLASH="${DIRECTORY_SLASH:-On}"
 
+# Request-hardening knobs (consumed by webdav.conf.template via envsubst).
+# Defaults are chosen to preserve prior behaviour except where the secure
+# default is harmless: LIMIT_REQUEST_BODY=0 keeps uploads unlimited;
+# DAV_DEPTH_INFINITY=Off blocks only recursive PROPFIND.
+export LIMIT_REQUEST_BODY="${LIMIT_REQUEST_BODY:-0}"
+export LIMIT_XML_REQUEST_BODY="${LIMIT_XML_REQUEST_BODY:-1048576}"
+export DAV_DEPTH_INFINITY="${DAV_DEPTH_INFINITY:-Off}"
+
 # ---------------------------------------------------------------------------
 # Write the auth directives block for a protected directory.
 # Depends on the active auth method (LDAP / OAuth / Basic / Digest).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -291,6 +291,12 @@ services:
       - "traefik.http.routers.webdav.rule=Host(`files.mydomain.com`)"
       - "traefik.http.routers.webdav.entrypoints=web"
       - "traefik.http.services.webdav.loadbalancer.server.port=8080"
+      # --- Rate limiting + connection cap (per client IP) ------------------
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.average=20"
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.burst=40"
+      - "traefik.http.middlewares.webdav-ratelimit.ratelimit.period=1s"
+      - "traefik.http.middlewares.webdav-inflight.inflightreq.amount=50"
+      - "traefik.http.routers.webdav.middlewares=webdav-ratelimit,webdav-inflight"
 
   traefik:
     image: traefik:v3.6.9
@@ -301,7 +307,8 @@ services:
     ports:
       - "80:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Read-only: Traefik only needs to read the Docker API, never write it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy
 
@@ -309,6 +316,12 @@ networks:
   proxy:
     driver: bridge
 ```
+
+> **Tuning:** `average`/`burst`/`period` throttle the request *rate* per client
+> IP; `inflightreq.amount` caps *simultaneous* in-flight requests. The limit is
+> keyed on the direct client IP by default — only add an
+> `ipstrategy.depth` if a CDN/proxy sits **in front of** Traefik, otherwise a
+> spoofed `X-Forwarded-For` can bypass it.
 
 ---
 

--- a/kubernetes/templates/_helpers.tpl
+++ b/kubernetes/templates/_helpers.tpl
@@ -22,3 +22,37 @@ Selector labels
 app.kubernetes.io/name: {{ include "webdav.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Detect OpenShift by the presence of its SecurityContextConstraints API group.
+Returns "true" on OpenShift, "" otherwise.
+*/}}
+{{- define "webdav.isOpenShift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}true{{- end -}}
+{{- end }}
+
+{{/*
+Pod-level securityContext.
+On OpenShift the restricted-v2 SCC assigns a random UID/GID from the namespace
+range and rejects a pinned runAsUser/fsGroup — and the image already supports
+arbitrary UIDs — so we omit those fields there. On plain Kubernetes we pin them
+to the values (the image's 'webuser' UID 999).
+*/}}
+{{- define "webdav.podSecurityContext" -}}
+runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+{{- with .Values.podSecurityContext.seccompProfile }}
+seccompProfile:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if not (include "webdav.isOpenShift" .) }}
+{{- with .Values.podSecurityContext.runAsUser }}
+runAsUser: {{ . }}
+{{- end }}
+{{- with .Values.podSecurityContext.runAsGroup }}
+runAsGroup: {{ . }}
+{{- end }}
+{{- with .Values.podSecurityContext.fsGroup }}
+fsGroup: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/kubernetes/templates/configmap.yaml
+++ b/kubernetes/templates/configmap.yaml
@@ -11,6 +11,9 @@ data:
   AUTO_CREATE_FOLDERS: {{ .Values.autoCreateFolders | quote }}
   RO_METHODS: {{ .Values.roMethods | quote }}
   RW_METHODS: {{ .Values.rwMethods | quote }}
+  LIMIT_REQUEST_BODY: {{ .Values.requestHardening.limitRequestBody | quote }}
+  LIMIT_XML_REQUEST_BODY: {{ .Values.requestHardening.limitXmlRequestBody | quote }}
+  DAV_DEPTH_INFINITY: {{ .Values.requestHardening.davDepthInfinity | quote }}
   BASIC_AUTH_ENABLED: {{ .Values.basicAuth.enabled | quote }}
   DIGEST_AUTH_ENABLED: {{ .Values.digestAuth.enabled | quote }}
   LDAP_ENABLED: {{ .Values.ldap.enabled | quote }}

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -17,10 +17,18 @@ spec:
       labels:
         {{- include "webdav.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- include "webdav.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: webdav
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           envFrom:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -18,6 +18,20 @@ roMethods: "GET HEAD OPTIONS PROPFIND"
 rwMethods: "GET HEAD OPTIONS PROPFIND PUT DELETE MKCOL COPY MOVE LOCK UNLOCK PROPPATCH"
 
 # ---------------------------------------------------------------------------
+# Request hardening (DoS / resource-exhaustion mitigations)
+# ---------------------------------------------------------------------------
+requestHardening:
+  # Quoted so Helm emits the exact digits — large ints otherwise render in
+  # scientific notation (e.g. 1.048576e+06), which Apache rejects.
+  # Max upload (PUT) body size in bytes. "0" = unlimited (default).
+  limitRequestBody: "0"
+  # Max WebDAV XML control body size in bytes (PROPFIND/PROPPATCH/LOCK).
+  # Does not affect file uploads. Default 1 MiB.
+  limitXmlRequestBody: "1048576"
+  # Allow recursive "Depth: infinity" PROPFIND. "Off" = blocked (recommended).
+  davDepthInfinity: "Off"
+
+# ---------------------------------------------------------------------------
 # Basic / Digest Authentication
 # ---------------------------------------------------------------------------
 basicAuth:
@@ -107,8 +121,30 @@ ingress:
 # ---------------------------------------------------------------------------
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: 100m
+    memory: 128Mi
   limits:
-    cpu: 500m
-    memory: 256Mi
+    cpu: "1"
+    memory: 1Gi
+
+# ---------------------------------------------------------------------------
+# Security context (pod- and container-level hardening)
+# Mirrors the docker-compose runtime hardening: non-root, no privilege
+# escalation, all capabilities dropped, default seccomp profile.
+# ---------------------------------------------------------------------------
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 999 # matches the existing 'webuser' UID baked into the image
+  runAsGroup: 999
+  fsGroup: 999 # makes the mounted PVC writable by the non-root user
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  # Left false: the entrypoint writes generated Apache config into
+  # /usr/local/apache2/conf at startup, so the root FS must stay writable.
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL

--- a/tests/test-security.sh
+++ b/tests/test-security.sh
@@ -285,12 +285,14 @@ test_security_headers() {
 
     headers=$(curl -s -I --connect-timeout 5 "${BASE_URL}/")
 
+    # These are set unconditionally in virtualhost.conf ("Header always set"),
+    # so they must be present on every response — including this 403.
     check_header() {
         local header="$1"
         if echo "$headers" | grep -qi "$header"; then
             pass "Header present: $header"
         else
-            skip "Header missing: $header (consider adding to virtualhost.conf)"
+            fail "Header missing: $header (expected from virtualhost.conf)"
         fi
     }
 
@@ -298,12 +300,68 @@ test_security_headers() {
     check_header "X-Frame-Options"
     check_header "Referrer-Policy"
 
+    # ServerTokens Prod — the Server header must not leak the Apache version/OS.
+    server_hdr=$(echo "$headers" | grep -i "^server:")
+    if echo "$server_hdr" | grep -qiE "apache/[0-9]"; then
+        fail "Server header leaks version (set ServerTokens Prod): $server_hdr"
+    else
+        pass "Server header does not leak version (ServerTokens Prod)"
+    fi
+
     # If CORS is enabled, check CORS header
     if echo "$headers" | grep -qi "Access-Control-Allow-Origin"; then
         pass "CORS header present: Access-Control-Allow-Origin"
     else
         skip "CORS header not present (expected if CORS_ENABLED=false)"
     fi
+}
+
+test_dav_depth_infinity() {
+    print_header "DavDepthInfinity Off (recursive PROPFIND)"
+
+    # Needs a PROPFIND-able location; use the public folder. Skip if it isn't
+    # reachable in this scenario (e.g. no public folder configured).
+    local depth0
+    depth0=$(http_status -X PROPFIND -H "Depth: 0" "${BASE_URL}${PUBLIC_FOLDER}/")
+    if [ "$depth0" != "207" ]; then
+        skip "Public folder not PROPFIND-able (HTTP $depth0) — skipping depth-infinity check"
+        return
+    fi
+
+    assert_status_in \
+        "PROPFIND Depth: infinity refused (DavDepthInfinity Off)" \
+        "403" \
+        -X PROPFIND -H "Depth: infinity" "${BASE_URL}${PUBLIC_FOLDER}/"
+}
+
+test_xml_request_body_limit() {
+    print_header "LimitXMLRequestBody (oversized control body)"
+
+    # Needs valid creds on a PROPFIND-able private folder. Skip otherwise
+    # (e.g. LDAP/OAuth scenarios where these Basic creds don't apply).
+    local ok
+    ok=$(http_status -u "$TEST_USER" -X PROPFIND -H "Depth: 0" "${BASE_URL}${PRIVATE_FOLDER}/")
+    if [ "$ok" != "207" ]; then
+        skip "Private folder not PROPFIND-able with test creds (HTTP $ok) — skipping XML-limit check"
+        return
+    fi
+
+    # ~1.1 MiB body, over the 1 MiB LimitXMLRequestBody default.
+    local big_xml
+    big_xml=$(mktemp)
+    {
+        printf '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><x>'
+        head -c 1100000 /dev/zero | tr '\0' 'A'
+        printf '</x></prop></propfind>'
+    } > "$big_xml"
+
+    assert_status_in \
+        "Oversized XML PROPFIND body rejected (LimitXMLRequestBody)" \
+        "413" \
+        -u "$TEST_USER" -X PROPFIND -H "Depth: 0" -H "Content-Type: text/xml" \
+        --data-binary @"$big_xml" "${BASE_URL}${PRIVATE_FOLDER}/"
+
+    rm -f "$big_xml"
 }
 
 test_health_check() {
@@ -339,6 +397,8 @@ test_write_permissions
 test_path_traversal
 test_user_isolation
 test_security_headers
+test_dav_depth_infinity
+test_xml_request_body_limit
 test_health_check
 
 # ---------------------------------------------------------------------------

--- a/virtualhost.conf
+++ b/virtualhost.conf
@@ -9,5 +9,10 @@
   ErrorLog /proc/self/fd/2
   # This lets certain DAV methods work behind an SSL reverse proxy.
   RequestHeader edit Destination ^https http early
-  
+
+  # Security headers — applied to all responses ("always" covers errors too).
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set X-Frame-Options "DENY"
+  Header always set Referrer-Policy "no-referrer"
+
 </VirtualHost>

--- a/webdav.conf
+++ b/webdav.conf
@@ -3,6 +3,32 @@ DavLockDB "${DAV_LOCK_DB}"
 # Disable TRACE method server-wide (information disclosure risk)
 TraceEnable Off
 
+# ---------------------------------------------------------------------------
+# Information disclosure — minimise what the server reveals about itself.
+# ---------------------------------------------------------------------------
+ServerTokens Prod
+ServerSignature Off
+
+# ---------------------------------------------------------------------------
+# Request hardening (DoS / resource-exhaustion mitigations).
+# ---------------------------------------------------------------------------
+# Slowloris / slow-POST: drop clients that dribble the request too slowly.
+RequestReadTimeout header=20-40,MinRate=500 body=20,MinRate=500
+
+# Cap the size of WebDAV XML control bodies (PROPFIND / PROPPATCH / LOCK).
+# This does NOT limit file uploads — only the XML messages — so it is safe to
+# keep tight. Guards against oversized/XML-bomb control requests.
+LimitXMLRequestBody ${LIMIT_XML_REQUEST_BODY}
+
+# Cap upload (PUT) body size. 0 = unlimited (default, preserves prior
+# behaviour). Set LIMIT_REQUEST_BODY to a byte count to prevent disk-fill DoS.
+LimitRequestBody ${LIMIT_REQUEST_BODY}
+
+# Refuse recursive "Depth: infinity" PROPFIND — a cheap request that forces a
+# full-tree walk (amplification vector). Affects PROPFIND only; COPY/MOVE/
+# DELETE of collections are unaffected. Set DAV_DEPTH_INFINITY=On to allow.
+DavDepthInfinity ${DAV_DEPTH_INFINITY}
+
 Alias / "/var/lib/dav/data/"
 
 # Root directory — deny all by default.


### PR DESCRIPTION
Adds defense-in-depth against brute-force and DoS, plus general hardening, across the proxy, Apache, the container, and the Helm chart. Behavior-preserving by default; the few defaults that changed match Apache's own defaults.

## Edge / brute-force
- Per-IP Traefik **rate-limit** + **in-flight** middleware on the `webdav` router. Keyed on the direct client IP (no `X-Forwarded-For` trust, since clients hit Traefik directly here).

## Apache request hardening (`webdav.conf`, env-tunable)
- `RequestReadTimeout` (slowloris / slow-POST)
- `LimitXMLRequestBody` (caps WebDAV control bodies; does not affect uploads)
- `LimitRequestBody` (default `0` = unlimited, no change)
- `DavDepthInfinity Off` (recursive PROPFIND amplification — also Apache's default)
- `ServerTokens Prod` / `ServerSignature Off` (info disclosure)
- Security headers: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`
- Load `mod_reqtimeout` in the Dockerfile
- New knobs exposed via `.env`: `LIMIT_REQUEST_BODY`, `LIMIT_XML_REQUEST_BODY`, `DAV_DEPTH_INFINITY`

## Container runtime hardening
- compose: `no-new-privileges`, `cap_drop: [ALL]`, resource limits, `docker.sock` mounted `:ro`
- Dockerfile: `chgrp 0` / `chmod g=u` so the image runs as an **arbitrary UID** (OpenShift `restricted-v2`)

## Kubernetes chart
- pod/container `securityContext`: `runAsNonRoot`, `drop: [ALL]`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`
- `isOpenShift` helper omits pinned UID/GID on OpenShift so the SCC assigns them; pins UID 999 on plain K8s
- request-hardening knobs in `values.yaml` + configmap; resource limits aligned with compose

## Tests
- `test-security.sh`: security headers now **hard-fail** (were skipped) + a `ServerTokens` version-leak check
- Added `DavDepthInfinity` (expect 403) and `LimitXMLRequestBody` (expect 413) checks, with graceful skips when preconditions aren't met
- security-tests workflow now also runs scenario-6 (write-ops)

## Verification
- Image builds; `httpd -t` syntax OK; rendered config verified as arbitrary UID and as UID 999
- `helm lint` + `helm template` pass for plain K8s and OpenShift (`--api-versions security.openshift.io/v1`)
- scenario-1 green (24 passed): `Depth: infinity` → 403, oversized XML → 413; skip path verified against a public-only server
- `docker compose config` valid
